### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Getting Ready
 [https://github.com/COx2/JUCE_JAPAN_DEMO]https://github.com/COx2/JUCE_JAPAN_DEMO
 
 ## Technologies Used
-C++ for the language
-JUCE for the framework/library
-Steinberg VST SDK
-Visual Studio for the IDE
+* C++ for the language
+* JUCE for the framework/library
+* Steinberg VST SDK
+* Visual Studio for the IDE


### PR DESCRIPTION
This PR adjusts looks of  README.

NOTE: If you want to show "new line" in Markdown on Github, you need to put two (or more) spaces at the end of line. BTW, I think that list is more adequate for enumerating technologies than plain text separated by new lines, so I used it on this PR.