### PR TITLE
コンパイラーによる警告の修正

### DIFF
--- a/Source/DSP/AmpEnvelope.cpp
+++ b/Source/DSP/AmpEnvelope.cpp
@@ -22,16 +22,16 @@ const float RELEASE_MIN = 0.001f;
 
 AmpEnvelope::AmpEnvelope(float attackTime, float decayTime, float sustain,
                          float releaseTime, float echoTime)
-    : _attackTime(attackTime),
+    : _ampState(AMPENV_STATE::WAIT),
+      _attackTime(attackTime),
       _decayTime(decayTime),
       _sustainValue(sustain),
       _releaseTime(releaseTime),
       _echoTime(echoTime),
-      _sampleRate(0.0f),
       _value(0.0f),
       _valueOnReleaseStart(0.0f),
       _timer(0.0f),
-      _ampState(AMPENV_STATE::WAIT) {
+      _sampleRate(0.0f) {
   checkVarRange();
 }
 

--- a/Source/DSP/ColorEnvelope.cpp
+++ b/Source/DSP/ColorEnvelope.cpp
@@ -70,6 +70,7 @@ float ColorEnvelope::getManipulateAngle() {
       return 0;
     }
   }
+  return 0;
 }
 
 void ColorEnvelope::clear() {

--- a/Source/DSP/SimpleVoice.cpp
+++ b/Source/DSP/SimpleVoice.cpp
@@ -1,4 +1,4 @@
-﻿#include "SimpleVoice.h"
+#include "SimpleVoice.h"
 
 namespace {
 const float HALF_PI = MathConstants<float>::halfPi;
@@ -15,23 +15,23 @@ SimpleVoice::SimpleVoice(
   MidiEchoParameters* midiEchoParams,
   WaveformMemoryParameters* waveformMemoryParams,
   WavePatternParameters* wavePatternParams)
-  : _chipOscParamsPtr(chipOscParams),
-    _sweepParamsPtr(sweepParams),
-    _vibratoParamsPtr(vibratoParams),
-    _voicingParamsPtr(voicingParams),
-    _optionsParamsPtr(optionsParams),
-    _midiEchoParamsPtr(midiEchoParams),
-    _waveformMemoryParamsPtr(waveformMemoryParams),
-    _wavePatternParams(wavePatternParams),
+  : eb((std::int32_t)getSampleRate(),
+    (float)midiEchoParams->EchoDuration->get(),
+  midiEchoParams->EchoRepeat->get()),
     ampEnv(chipOscParams->Attack->get(), chipOscParams->Decay->get(),
             chipOscParams->Sustain->get(), chipOscParams->Release->get(),
             midiEchoParams->EchoDuration->get() * midiEchoParams->EchoRepeat->get()),
     vibratoEnv(vibratoParams->VibratoAttackTime->get(), 0.1f, 1.0f, 0.1f, 0.0f),
     portaEnv(voicingParams->StepTime->get(), 0.0f, 1.0f, 0.0f, 0.0f),
     colorEnv(chipOscParams),
-    eb((std::int32_t)getSampleRate(),
-        (float)midiEchoParams->EchoDuration->get(),
-      midiEchoParams->EchoRepeat->get()) {
+    _chipOscParamsPtr(chipOscParams),
+    _sweepParamsPtr(sweepParams),
+    _vibratoParamsPtr(vibratoParams),
+    _voicingParamsPtr(voicingParams),
+    _optionsParamsPtr(optionsParams),
+    _midiEchoParamsPtr(midiEchoParams),
+    _waveformMemoryParamsPtr(waveformMemoryParams),
+    _wavePatternParams(wavePatternParams) {
   clear();
 }
 

--- a/Source/DSP/SimpleVoice.cpp
+++ b/Source/DSP/SimpleVoice.cpp
@@ -17,7 +17,7 @@ SimpleVoice::SimpleVoice(
   WavePatternParameters* wavePatternParams)
   : eb((std::int32_t)getSampleRate(),
     (float)midiEchoParams->EchoDuration->get(),
-  midiEchoParams->EchoRepeat->get()),
+    midiEchoParams->EchoRepeat->get()),
     ampEnv(chipOscParams->Attack->get(), chipOscParams->Decay->get(),
             chipOscParams->Sustain->get(), chipOscParams->Release->get(),
             midiEchoParams->EchoDuration->get() * midiEchoParams->EchoRepeat->get()),

--- a/Source/EditorGUI.cpp
+++ b/Source/EditorGUI.cpp
@@ -18,6 +18,7 @@ EditorGUI::EditorGUI(PluginProcessor &p)
                         MidiKeyboardComponent::Orientation::horizontalKeyboard),
       OscButton("Wave", this),
       EffectButton("Effects", this),
+      scopeComponent(p.getAudioBufferQueue()),
       chipOscComponent(&p.chipOscParameters),
       sweepParamsComponent(&p.sweepParameters),
       vibratoParamsComponent(&p.vibratoParameters),
@@ -26,8 +27,7 @@ EditorGUI::EditorGUI(PluginProcessor &p)
       waveformMemoryParamsComponent(&p.waveformMemoryParameters),
       midiEchoParamsComponent(&p.midiEchoParameters),
       filterParamsComponent(&p.filterParameters),
-      wavePatternsComponent(&p.wavePatternParameters),
-      scopeComponent(p.getAudioBufferQueue()) {
+      wavePatternsComponent(&p.wavePatternParameters) {
   /*
           TabComponentを使いたかったが，Tabだとメモリリークが収まらないので現在の形に．
           デストラクタ時にメモリリーク，CustomLookAndFeelまわりでエラーが取れない．

--- a/Source/GUI/ComponentUtil.hpp
+++ b/Source/GUI/ComponentUtil.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "JuceHeader.h"
+#include <optional>
 
 struct Trail {
   Trail(const MouseInputSource& ms) : source(ms) {}
@@ -47,7 +48,7 @@ class TextSlider : public Component {
 
   TextSlider(std::string labelName, std::string unit, float value, float start,
              float end, Slider::Listener *listener, float degree = 0.1f,
-             float pivot = NULL)
+             std::optional<float> pivot = {})
       : slider(Slider::SliderStyle::LinearHorizontal,
                Slider::TextEntryBoxPosition::TextBoxLeft) {
     slider.setRange(start, end, degree);
@@ -55,8 +56,8 @@ class TextSlider : public Component {
     slider.setTextValueSuffix(std::string(" ") + unit);
     slider.addListener(listener);
 
-    if (pivot != NULL) {
-      slider.setSkewFactorFromMidPoint(pivot);
+    if (!pivot) {
+      slider.setSkewFactorFromMidPoint(*pivot);
     }
 
     label.setText(labelName, dontSendNotification);

--- a/Source/GUI/ComponentUtil.hpp
+++ b/Source/GUI/ComponentUtil.hpp
@@ -56,7 +56,7 @@ class TextSlider : public Component {
     slider.setTextValueSuffix(std::string(" ") + unit);
     slider.addListener(listener);
 
-    if (!pivot) {
+    if (pivot.has_value()) {
       slider.setSkewFactorFromMidPoint(*pivot);
     }
 

--- a/Source/GUI/ParametersComponent.cpp
+++ b/Source/GUI/ParametersComponent.cpp
@@ -99,7 +99,7 @@ static void loadWaveFile(WaveformMemoryParameters* _waveformMemoryParamsPtr, std
       File waveformFile(result);
       std::string data = waveformFile.loadFileAsString().toStdString();
       auto count = 0;
-      for (const auto subStr : split(data, ' ')) {
+      for (const auto &subStr : split(data, ' ')) {
       *_waveformMemoryParamsPtr->WaveSamplesArray[count] = atoi(subStr.c_str());
       ++count;
       }
@@ -587,7 +587,7 @@ void WaveformMemoryParametersComponent::filesDropped(const StringArray& files,
     File waveformFile(filePath);
     std::string data = waveformFile.loadFileAsString().toStdString();
     std::int32_t count = 0;
-    for (const auto subStr : split(data, ' ')) {
+    for (const auto &subStr : split(data, ' ')) {
       *_waveformMemoryParamsPtr->WaveSamplesArray[count] = atoi(subStr.c_str());
       ++count;
     }
@@ -601,7 +601,7 @@ void WaveformMemoryParametersComponent::fileClicked(const File& file, const Mous
     File waveformFile(filePath);
     std::string data = waveformFile.loadFileAsString().toStdString();
     std::int32_t count = 0;
-    for (const auto subStr : split(data, ' ')) {
+    for (const auto &subStr : split(data, ' ')) {
       *_waveformMemoryParamsPtr->WaveSamplesArray[count] = atoi(subStr.c_str());
       ++count;
     }

--- a/Source/GUI/ParametersComponent.cpp
+++ b/Source/GUI/ParametersComponent.cpp
@@ -24,7 +24,7 @@ static File getPreFileDirectory(File* file) {
 }
 
 static std::vector<std::string> split(std::string str, char del) {
-  auto first = 0;
+  size_t first = 0;
   auto last = str.find_first_of(del);
 
   std::vector<std::string> result;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -48,8 +48,8 @@ PluginProcessor ::PluginProcessor ()
       filterParameters(
         new AudioParameterBool("HICUT_ENABLE", "Filter-Hicut-Enable", false),
         new AudioParameterBool("LOWCUT_ENABLE", "Filter-Lowcut-Enable", false),
-          new AudioParameterFloat("FILTER_HICUT-FREQ", "Filter-Hicut-Freq", 40.0f, 20000.0f, 20000.0f),
-          new AudioParameterFloat("FILTER_LOWCUT-FREQ", "Filter-Lowcut-Freq", 40.0f, 20000.0f, 40.0f)),
+        new AudioParameterFloat("FILTER_HICUT-FREQ", "Filter-Hicut-Freq", 40.0f, 20000.0f, 20000.0f),
+        new AudioParameterFloat("FILTER_LOWCUT-FREQ", "Filter-Lowcut-Freq", 40.0f, 20000.0f, 40.0f)),
       presetsParameters(),
       wavePatternParameters(),
       scopeDataCollector(scopeDataQueue) {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -15,7 +15,6 @@ AudioProcessor* JUCE_CALLTYPE createPluginFilter() {
 
 PluginProcessor ::PluginProcessor ()
     : BaseAudioProcessor(),
-      presetsParameters(),
       chipOscParameters(
         new AudioParameterChoice("OSC_WAVE_TYPE", "Osc-WaveType", OSC_WAVE_TYPES, 0),
         new AudioParameterFloat("VOLUME", "Volume", -32.0f, 8.0f, -20.0f),
@@ -40,6 +39,7 @@ PluginProcessor ::PluginProcessor ()
       optionsParameters(
         new AudioParameterInt("PITCH_BEND_RANGE", "Pitch-Bend-Range", 1, 13, 2),
         new AudioParameterInt("PITCH_STANDARD", "Pitch-Standard", 400, 500, 440)),
+      waveformMemoryParameters(),
       midiEchoParameters(
         new AudioParameterBool("ECHO_ENABLE", "Echo-Enable", false),
         new AudioParameterFloat("ECHO_DURATION", "Echo-Duration", {0.01f, 3.0f, MIN_DELTA}, 0.1f),
@@ -48,9 +48,9 @@ PluginProcessor ::PluginProcessor ()
       filterParameters(
         new AudioParameterBool("HICUT_ENABLE", "Filter-Hicut-Enable", false),
         new AudioParameterBool("LOWCUT_ENABLE", "Filter-Lowcut-Enable", false),
-        new AudioParameterFloat("FILTER_HICUT-FREQ", "Filter-Hicut-Freq", 40.0f, 20000.0f, 20000.0f),
-        new AudioParameterFloat("FILTER_LOWCUT-FREQ", "Filter-Lowcut-Freq", 40.0f, 20000.0f, 40.0f)),
-      waveformMemoryParameters(),
+          new AudioParameterFloat("FILTER_HICUT-FREQ", "Filter-Hicut-Freq", 40.0f, 20000.0f, 20000.0f),
+          new AudioParameterFloat("FILTER_LOWCUT-FREQ", "Filter-Lowcut-Freq", 40.0f, 20000.0f, 40.0f)),
+      presetsParameters(),
       wavePatternParameters(),
       scopeDataCollector(scopeDataQueue) {
   presetsParameters.addAllParameters(*this);


### PR DESCRIPTION
ビルドしてみたところ, 正常にビルドできるもののいくつかのコードに対してコンパイラーが警告を出したため, それらを修正してみました.

- クラスのメンバ変数の初期化子の順序を宣言順序と一致させた
- 戻り値がある関数で `return` しない分岐を修正
- `TextSlider` の `pivot` に `NULL` ではなく `optional` を利用して任意引数を表現するように修正
- コンストラクタ名に不要な量化を行っている部分を除去
- `split` の実行結果を範囲 `for` でループさせている箇所での不要なコピーを抑制
- インデックスの型を `size_t` に置換
